### PR TITLE
Dependency fix

### DIFF
--- a/Items/Tier1/AmethystTicket.cs
+++ b/Items/Tier1/AmethystTicket.cs
@@ -1,4 +1,5 @@
-﻿using Terraria.ModLoader;
+using Terraria;
+using Terraria.ModLoader;
 
 namespace EnemyMods.Items.Tier1
 {

--- a/Items/Tier2/TopazTicket.cs
+++ b/Items/Tier2/TopazTicket.cs
@@ -1,4 +1,5 @@
-﻿using Terraria.ModLoader;
+using Terraria;
+using Terraria.ModLoader;
 
 namespace EnemyMods.Items.Tier2
 {

--- a/Items/Tier3/SapphireTicket.cs
+++ b/Items/Tier3/SapphireTicket.cs
@@ -1,4 +1,5 @@
-﻿using Terraria.ModLoader;
+using Terraria;
+using Terraria.ModLoader;
 
 namespace EnemyMods.Items.Tier3
 {

--- a/Items/Tier4/EmeraldTicket.cs
+++ b/Items/Tier4/EmeraldTicket.cs
@@ -1,4 +1,5 @@
-﻿using Terraria.ModLoader;
+using Terraria;
+using Terraria.ModLoader;
 
 namespace EnemyMods.Items.Tier4
 {

--- a/Items/Tier5/RubyTicket.cs
+++ b/Items/Tier5/RubyTicket.cs
@@ -1,4 +1,5 @@
-﻿using Terraria.ModLoader;
+using Terraria;
+using Terraria.ModLoader;
 
 namespace EnemyMods.Items.Tier5
 {

--- a/Items/Tier6/AmberTicket.cs
+++ b/Items/Tier6/AmberTicket.cs
@@ -1,4 +1,5 @@
-﻿using Terraria.ModLoader;
+using Terraria;
+using Terraria.ModLoader;
 
 namespace EnemyMods.Items.Tier6
 {

--- a/NPCs/gNPC.cs
+++ b/NPCs/gNPC.cs
@@ -51,7 +51,7 @@ namespace EnemyMods.NPCs
         public override bool CloneNewInstances => true;
         public override void SetDefaults(NPC npc)
         {
-            if (Main.netMode == 1 || npc == null || npc.FullName == null)//if multiplayer, but not server. 1 is client in MP, 2 is server. Prefixes are sent to client by server in MP.
+            if (Main.rand == null || Main.netMode == 1 || npc == null || npc.FullName == null)//if multiplayer, but not server. 1 is client in MP, 2 is server. Prefixes are sent to client by server in MP.
             {
                 return;
             }


### PR DESCRIPTION
This should fix the famous (on the forums) "kenneth" error which has absolutely nothing to do with kenneth
(who is just a user folder name) and everything to do with missing DLL which is built in Terraria.exe
I just pushed this by trial & error, but this works for my system, it doesn't depend anymore on cheatsheet presence to go past the error.

Basically all tickets were missing "using Terraria;"

also added a check for Main.rand is null cause it was causing problems "Object reference not set to an instance of an object" when coupled with other big mods (thorium, calamity...)